### PR TITLE
Implement continuous training for Whoop data

### DIFF
--- a/orchestrator/dagster_app/repository.py
+++ b/orchestrator/dagster_app/repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from dagster import job, op, Definitions
+from dagster import job, op, Definitions, ScheduleDefinition
 
 # Extend sys.path for module imports
 import sys
@@ -56,4 +56,10 @@ def hrv_daily_job():
     _a = agent_op()
 
 
-defs = Definitions(jobs=[hrv_daily_job])
+daily_schedule = ScheduleDefinition(
+    job=hrv_daily_job,
+    cron_schedule="0 5 * * *",  # 05:00 UTC daily
+    execution_timezone="UTC",
+)
+
+defs = Definitions(jobs=[hrv_daily_job], schedules=[daily_schedule])

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -1,3 +1,5 @@
 numpy>=2.0.0
 pytest>=8.3.2
 openai>=1.46.0
+scikit-learn>=1.5.0
+xgboost>=2.0.0


### PR DESCRIPTION
Enable continuous training with multiple MLflow-integrated models and a daily Dagster schedule to adapt to evolving Whoop data and improve recovery predictions.

---
Linear Issue: [BES-24](https://linear.app/best-pm/issue/BES-24/understand-continuous-training)

<a href="https://cursor.com/background-agent?bcId=bc-4e688c56-af5b-4e0a-8d4c-6be539d07bcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e688c56-af5b-4e0a-8d4c-6be539d07bcb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

